### PR TITLE
fix: 使用 yarn 修复编译报错失败

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
   "dependencies": {
     "react": "17.0.0-rc.0",
     "react-dom": "17.0.0-rc.0"
+  },
+  "resolutions": {
+    "@types/react": "^16.9.41"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2226,15 +2226,7 @@
   dependencies:
     "@types/react" "^16"
 
-"@types/react@*":
-  version "17.0.0"
-  resolved "https://registry.npm.taobao.org/@types/react/download/@types/react-17.0.0.tgz?cache=0&sync_timestamp=1606158558386&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Freact%2Fdownload%2F%40types%2Freact-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
-  integrity sha1-WvPrf60oBwkvAEahMCt4I+J5Gbg=
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16", "@types/react@^16.9.41":
+"@types/react@*", "@types/react@^16", "@types/react@^16.9.41":
   version "16.14.2"
   resolved "https://registry.npm.taobao.org/@types/react/download/@types/react-16.14.2.tgz?cache=0&sync_timestamp=1606158558386&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Freact%2Fdownload%2F%40types%2Freact-16.14.2.tgz#85dcc0947d0645349923c04ccef6018a1ab7538c"
   integrity sha1-hdzAlH0GRTSZI8BMzvYBihq3U4w=


### PR DESCRIPTION
我这边是使用 yarn 来安装的，在执行 yarn dev 之后，发现有一堆的报错，这个时候需要找到最开始报错的提示信息，如下
```
Duplicate identifier 'LibraryManagedAttributes'
```
于是在 [stackoverflow 的这个帖子下找到解决方案](https://stackoverflow.com/questions/52399839/duplicate-identifier-librarymanagedattributes)，大意是说在 yarn.lock 中，`@types/react-dom` 依赖于 `@types/react`的任何版本，但是 yarn 现在 resolve `@types/react` 有两个版本，所以有重复(Duplicate) 的提示，这个时候需要修改 `package.json` 中加上需要 resolve 的 `@types/react` 的指定版本即可，然后再执行 `yarn`，最后再执行 `yarn dev`，报错提示消失